### PR TITLE
nethserver-alerts-update-alertsdb: change created db ownership

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-alerts-update-alertsdb
+++ b/root/etc/e-smith/events/actions/nethserver-alerts-update-alertsdb
@@ -2,7 +2,7 @@
 
 SYSTEMID=$(/sbin/e-smith/config getprop nethupdate SystemID)
 
-ALERTSDBJSON=$(/usr/bin/curl -s "https://my.nethesis.it/api/customalerts/configuration?system_key=$SYSTEMID")
+ALERTSDBJSON=$(/usr/bin/curl -ks "https://my.nethesis.it/api/customalerts/configuration?system_key=$SYSTEMID")
 RES1=$?
 
 if [[ $RES1 == 0 ]] ; then


### PR DESCRIPTION
Change created db ownership to allow read permission to NethGUI

Nethesis/dev#5180